### PR TITLE
refactor DoctrineCacheAdapter:getItem() to properly implement PSR-6

### DIFF
--- a/Component/Adapter/DoctrineCacheAdapter.php
+++ b/Component/Adapter/DoctrineCacheAdapter.php
@@ -34,14 +34,14 @@ class DoctrineCacheAdapter implements CacheItemPoolInterface
      */
     public function getItem($key)
     {
-        if (true === $this->provider->contains($key)) {
-            $item = $this->provider->fetch($key);
-            $item->setHit(true);
-
-            return $item;
-        } else {
+        if (false === $this->provider->contains($key)) {
             return new CacheItem($key);
         }
+
+        $item = $this->provider->fetch($key);
+        $item->setHit(true);
+
+        return $item;
     }
 
     /**
@@ -55,11 +55,7 @@ class DoctrineCacheAdapter implements CacheItemPoolInterface
 
         $items = [];
         foreach ($keys as $key) {
-            if (true === $this->provider->contains($key)) {
-                $items[$key] = $this->fetchCacheItem($key);
-            } else {
-                $items[$key] = null;
-            }
+            $items[$key] = $this->getItem($key);
         }
 
         return $items;
@@ -132,22 +128,5 @@ class DoctrineCacheAdapter implements CacheItemPoolInterface
         }
 
         return $this->provider->save($item->getKey(), $item, $ttl);
-    }
-
-    /**
-     * @param string $key
-     * @return CacheItemInterface|null
-     */
-    public function fetchCacheItem($key)
-    {
-        $item = $this->provider->fetch($key);
-
-        if (false !== $item) {
-            $item->setHit(true);
-
-            return $item;
-        }
-
-        return null;
     }
 }

--- a/Tests/Adapter/DoctrineCacheAdapterTest.php
+++ b/Tests/Adapter/DoctrineCacheAdapterTest.php
@@ -14,7 +14,7 @@ use Doctrine\Common\Cache\CacheProvider;
 use Egils\Component\Cache\Adapter\DoctrineCacheAdapter;
 use PHPUnit_Framework_TestCase as TestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
-use Psr\Cache\CacheItemInterface;
+use Egils\Component\Cache\CacheItem;
 
 class DoctrineCacheAdapterTest extends TestCase
 {
@@ -24,8 +24,11 @@ class DoctrineCacheAdapterTest extends TestCase
     /** @var CacheProvider|MockObject */
     private $cacheProvider;
 
-    /** @var CacheItemInterface|MockObject */
+    /** @var CacheItem|MockObject */
     private $cacheItem;
+
+    /** @var string */
+    private $cacheKey;
 
     public function setUp()
     {
@@ -40,21 +43,49 @@ class DoctrineCacheAdapterTest extends TestCase
         );
         $this->adapter = new DoctrineCacheAdapter($this->cacheProvider);
 
-        $this->cacheItem = $this->getMock('Psr\Cache\CacheItemInterface');
+        $this->cacheKey = 'cache-key';
+        $this->cacheItem = $this->getMock('Egils\Component\Cache\CacheItem', [], [$this->cacheKey]);
     }
 
     public function testGetItem()
     {
-        $key = 'cache-key';
         $this->cacheProvider
             ->expects($this->once())
             ->method('fetch')
-            ->with($key)
+            ->with($this->cacheKey)
             ->willReturn($this->cacheItem);
+
+        $this->cacheProvider
+            ->expects($this->once())
+            ->method('contains')
+            ->with($this->cacheKey)
+            ->willReturn(true);
+
+        $this->cacheItem
+            ->expects($this->once())
+            ->method('setHit')
+            ->with(true)
+            ->willReturn($this->cacheItem);
+
+        $cacheItem = $this->adapter->getItem($this->cacheKey);
+
+        $this->assertSame($this->cacheItem, $cacheItem);
+    }
+
+    public function testGetItem_ItemNotFound()
+    {
+        $key = 'cache-key';
+        $this->cacheProvider
+            ->expects($this->once())
+            ->method('contains')
+            ->with($key)
+            ->willReturn(false);
 
         $cacheItem = $this->adapter->getItem($key);
 
-        $this->assertSame($this->cacheItem, $cacheItem);
+        $this->assertInstanceOf('Psr\Cache\CacheItemInterface', $cacheItem);
+        $this->assertEquals($key, $cacheItem->getKey());
+        $this->assertFalse($cacheItem->isHit());
     }
 
     public function testGetItems_EmptyKeysSetGiven()
@@ -66,14 +97,14 @@ class DoctrineCacheAdapterTest extends TestCase
 
     public function testGetItems_AllItemsFound()
     {
-        $keys = ['cache-key-1', 'cache-key-2'];
+        $keys = [$this->cacheKey, 'cache-key-2'];
         $this->cacheProvider
             ->expects($this->exactly(count($keys)))
             ->method('contains')
             ->withConsecutive([$keys[0]], [$keys[1]])
             ->willReturn(true);
 
-        $otherCacheItem = $this->getMock('Psr\Cache\CacheItemInterface');
+        $otherCacheItem = $this->getMock('Egils\Component\Cache\CacheItem', [], [$keys[1]]);
         $this->cacheProvider
             ->expects($this->exactly(count($keys)))
             ->method('fetch')
@@ -88,13 +119,13 @@ class DoctrineCacheAdapterTest extends TestCase
 
     public function testGetItems_OnlySecondItemFound()
     {
-        $keys = ['cache-key-1', 'cache-key-2'];
+        $keys = [$this->cacheKey, 'cache-key-2'];
         $this->cacheProvider
             ->expects($this->exactly(count($keys)))
             ->method('contains')
             ->willReturnMap([[$keys[0], false], [$keys[1], true]]);
 
-        $otherCacheItem = $this->getMock('Psr\Cache\CacheItemInterface');
+        $otherCacheItem = $this->getMock('Egils\Component\Cache\CacheItem', [], [$keys[1]]);
         $this->cacheProvider
             ->expects($this->once())
             ->method('fetch')
@@ -111,14 +142,14 @@ class DoctrineCacheAdapterTest extends TestCase
 
     public function testGetItems_FirstFetchFailed()
     {
-        $keys = ['cache-key-1', 'cache-key-2'];
+        $keys = [$this->cacheKey, 'cache-key-2'];
         $this->cacheProvider
             ->expects($this->exactly(count($keys)))
             ->method('contains')
             ->withConsecutive([$keys[0]], [$keys[1]])
             ->willReturn(true);
 
-        $otherCacheItem = $this->getMock('Psr\Cache\CacheItemInterface');
+        $otherCacheItem = $this->getMock('Egils\Component\Cache\CacheItem', [], [$keys[1]]);
         $this->cacheProvider
             ->expects($this->exactly(count($keys)))
             ->method('fetch')
@@ -144,20 +175,19 @@ class DoctrineCacheAdapterTest extends TestCase
 
     public function testDeleteItems()
     {
-        $key = 'cache-key';
         $this->cacheProvider
             ->expects($this->once())
             ->method('contains')
-            ->with($key)
+            ->with($this->cacheKey)
             ->willReturn(true);
 
         $this->cacheProvider
             ->expects($this->once())
             ->method('delete')
-            ->with($key)
+            ->with($this->cacheKey)
             ->willReturn(true);
 
-        $cacheItemPool = $this->adapter->deleteItems([$key]);
+        $cacheItemPool = $this->adapter->deleteItems([$this->cacheKey]);
         $this->assertInstanceOf('Psr\Cache\CacheItemPoolInterface', $cacheItemPool);
     }
 
@@ -182,7 +212,6 @@ class DoctrineCacheAdapterTest extends TestCase
     {
         date_default_timezone_set('Europe/Vilnius');
 
-        $cacheKey = 'cache-key';
         $this->cacheItem
             ->expects($this->once())
             ->method('getExpiration')
@@ -190,12 +219,12 @@ class DoctrineCacheAdapterTest extends TestCase
         $this->cacheItem
             ->expects($this->once())
             ->method('getKey')
-            ->willReturn($cacheKey);
+            ->willReturn($this->cacheKey);
 
         $this->cacheProvider
             ->expects($this->once())
             ->method('save')
-            ->with($cacheKey, $this->cacheItem, 30)
+            ->with($this->cacheKey, $this->cacheItem, 30)
             ->willReturn(true);
 
         $cacheItemPool = $this->adapter->save($this->cacheItem);
@@ -204,8 +233,8 @@ class DoctrineCacheAdapterTest extends TestCase
 
     public function testSaveDeferredAndCommit()
     {
-        $keys = ['cache-key-1', 'cache-key-2'];
-        $otherCacheItem = $this->getMock('Psr\Cache\CacheItemInterface');
+        $keys = [$this->cacheKey, 'cache-key-2'];
+        $otherCacheItem = $this->getMock('Egils\Component\Cache\CacheItem', [], [$keys[1]]);
 
         $this->cacheItem
             ->expects($this->once())
@@ -230,9 +259,8 @@ class DoctrineCacheAdapterTest extends TestCase
         $this->assertTrue($this->adapter->commit());
     }
 
-    public function testSaveDeferredAndCommit_SeconSaveFails()
+    public function testSaveDeferredAndCommit_SecondSaveFails()
     {
-        $keys = ['cache-key-1', 'cache-key-2'];
         $otherCacheItem = $this->getMock('Psr\Cache\CacheItemInterface');
 
         $this->cacheItem


### PR DESCRIPTION
This PR _is a BC break_ if `DoctrineCacheAdapter` was used with other `Psr\Cache\CacheItemInterface` implementation than provided with this package!

This fixes #1 
