### PR TITLE
remove replace declaration from composer.json as psr/cache has been f…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,6 @@
     "provide": {
         "psr/cache-implementation": "1.0.0"
     },
-    "replace": {
-        "psr/cache": "1.0.0"
-    },
     "suggest": {
         "doctrine/cache": "Various cache drivers that can be used with DoctrineCacheAdapter"
     },


### PR DESCRIPTION
…inalised

If you're trying to replace this package with `psr/cache` it's very difficult because this package is declared as replacing it, whereas since the Recommendation status of PSR-6 in December that package replaces this.  Would be great if you could update this package so Packagist doesn't incorrectly use this package instead of `psr/cache`.  Thanks!
